### PR TITLE
remove skip to content in the header

### DIFF
--- a/src/routes/(user)/[lang]/+layout.svelte
+++ b/src/routes/(user)/[lang]/+layout.svelte
@@ -4,7 +4,6 @@
   import { t } from '$lib/translations/translations';
 </script>
 
-<a class="skiptocontent" href="#main">{$t('common.skiptocontent')}</a>
 <div class="flex flex-col justify-between h-screen">
   <Header />
 
@@ -23,24 +22,5 @@
     height: 285px;
     visibility: hidden;
     pointer-events: none;
-  }
-
-  .skiptocontent {
-    position: absolute;
-    top: 3px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: -2000;
-    border: 1px solid var(--color-text-inverted);
-    color: var(--color-text-inverted);
-    padding: 0.3rem 1.5rem;
-    background-color: var(--color-bg-secondary);
-    border-radius: 0.2rem;
-    font-size: large;
-  }
-
-  .skiptocontent:focus,
-  .skiptocontent:active {
-    z-index: 2000;
   }
 </style>


### PR DESCRIPTION
Dette er en slik en boks som dukker opp når du er på en matside f.eks og skal se på en oppskrift til mat, og så snakker de mye og historien bak. Så kommer det noen ganger en slik skip to recipe knapp som en kan trykke på som fører en rett til oppskriften. Dette var noe lignende, men var ikke særlig nødvendig for sida vil jeg påstå.
Denne hadde ingen funksjon for nettsida, var ikke synlig til vanlig under noen omstendigheter, bortsett fra når en tabulerte fra startsida, så derfor ikke nytten av denne.